### PR TITLE
fix: add authorization header in twitch helix requests

### DIFF
--- a/main.js
+++ b/main.js
@@ -55,23 +55,22 @@
     }
   }
 
-  // Call the Twitch API to check is a liveis in progress
-  //
-  // @return { Promise => Boolean }
+  /**
+   * Call the Twitch API to check is a liveis in progress
+   * @returns {Promise<boolean>}
+   */
   async function checkLiveStatus() {
-    var data = await fetch(TWITCH_URL,{
+    const streams = await fetch(TWITCH_URL, {
       headers: {
-        'Authorization': `Bearer ${oauth.access_token}`,
-        'Client-ID': TWITCH_ID
-      }}).then((data) => {
-      return data.json()
-    });
+        "Authorization": `Bearer ${oauth.access_token}`,
+        "Client-ID": TWITCH_ID
+      }
+    }).then(res => res.json());
 
-    var isOn = Boolean(Array.isArray(data.data) //stream is online
-      &&
-      data.data.length) //the stream is live https://dev.twitch.tv/docs/api/reference#get-streams
-
-    return isOn ? data.data[0] : null
+    // Computing condition to tell if the stream is live or not.
+    // Further information here: https://dev.twitch.tv/docs/api/reference#get-streams
+    const isOn = Boolean(Array.isArray(streams.data) && streams.data.length);
+    return isOn ? streams.data[0] : null
   }
 
   // Update the browser action badge

--- a/main.js
+++ b/main.js
@@ -1,5 +1,3 @@
-
-
 (function(browser) {
 
   // Useful constants

--- a/main.js
+++ b/main.js
@@ -12,7 +12,7 @@
 
   // Global status
   // --------------------------------------------------------------------------
-  let accessToken = null;
+  let oauth = null;
   var isLive = false;
 
   // Extension logic
@@ -42,9 +42,10 @@
         grant_type: "client_credentials"
       })
     });
-    accessToken = await res.json();
+    oauth = await res.json();
 
-    setTimeout(retrieveAccessToken, accessToken.expires_in - 5 * 60);
+    // We'll ask for a new access token 5 minute before
+    setTimeout(retrieveAccessToken, oauth.expires_in - 5 * 60);
   }
 
   // Call the Twitch API to check is a liveis in progress
@@ -141,8 +142,6 @@
     browser.notifications.onClicked.addListener(openTab);
   }
 
-  // Start checking the live status
-  // --------------------------------------------------------------------------
-  onLiveChange()
-
-}(window.browser || window.chrome));
+  // Retrieves access token then we start to check live status
+  retrieveAccessToken().then(() => onLiveChange());
+})(window.browser || window.chrome);

--- a/main.js
+++ b/main.js
@@ -6,11 +6,13 @@
   // --------------------------------------------------------------------------
   const TWITCH_ID = "gjds1hg0hy0zanu764903orz2adzsy";
   const TWITCH_URL = "https://api.twitch.tv/helix/streams?user_login=accropolis";
+  const TWITCH_SECRET = "";
   const DELAY = 10; // minute
   const REFRESH_TIME = 2 * 60 * 1000; //2min
 
   // Global status
   // --------------------------------------------------------------------------
+  let accessToken = null;
   var isLive = false;
 
   // Extension logic
@@ -24,6 +26,25 @@
     await browser.tabs.create({
       url: isLive ? "https://www.twitch.tv/accropolis" : "http://accropolis.fr"
     })
+  }
+
+  /**
+   * Requests an access token to Twitch authentication API.
+   * @async
+   * @returns {Promise<void>}
+   */
+  async function retrieveAccessToken() {
+    const res = await fetch("https://id.twitch.tv/oauth2/token", {
+      method: 'POST',
+      body: new URLSearchParams({
+        client_id: TWITCH_ID,
+        client_secret: TWITCH_SECRET,
+        grant_type: "client_credentials"
+      })
+    });
+    accessToken = await res.json();
+
+    setTimeout(retrieveAccessToken, accessToken.expires_in - 5 * 60);
   }
 
   // Call the Twitch API to check is a liveis in progress

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_title__",
-  "version": "1.3",
+  "version": "1.3.1",
   "default_locale": "fr",
 
   "description": "__MSG_description__",

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,8 @@
   },
 
   "permissions": [
-    "notifications"
+    "notifications",
+    "storage"
   ],
 
   "background": {


### PR DESCRIPTION
Cette PR résout le problème de rafraîchissement évoqué dans #8. Pour le résoudre, on va récupérer un jeton d'authentification OAuth lorsque l'extension est lancée pour pouvoir autoriser nos futures requêtes.

## Détails

Je me suis reposé sur [l'authentification d'un client OAuth](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-client-credentials-flow) donnée dans la documentation Twitch pour récupérer le jeton d'accès.

Je me sers également de l'API [Web Storage](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/local) pour éviter de refaire une requête pour récupérer un jeton d'accès à chaque fois que le navigateur est lancé.

Il faut par contre rajouter un "secret" qui est lié à l'application enregistrée dans Twitch pour qu'on puisse obtenir ces jetons. C'est le rôle de la nouvelle constante `TWITCH_SECRET`.

> Pour tester j'ai généré un secret avec mon compte Twitch personnel, mais je n'ai pas rajouté ce secret dans le code source, il faut qu'on le mette avant de merge cette PR.
>
> Aussi rajouter une telle information en dur dans le code source public n'est pas une bonne pratique de sécurité parce qu'il permet de faire des actions qui ont un impact sur le compte Twitch. Je suis preneur de bonnes idées pour éviter de le mettre tel quel dans le code 😕

## Tests

Testé sur Firefox 78.0b4
Testé sur Chrome 83.0.4103.116

## Issues liées

Résout #8.